### PR TITLE
Add GitHub Action for building & deploying frontend

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,6 +22,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+    - uses: vafinvr/template-env-action@master
+      continue-on-error: true
+      env:
+        API_URL: ${{ secrets.API_URL }}
+      with:
+        filename: frontend/.env
     - name: Cache dependencies
       uses: actions/cache@v2
       with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,54 @@
+name: Build & Deploy Frontend
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'frontend/**'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'frontend/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - run: npm ci
+    - run: npm test
+    - run: npm run build
+    - name: Upload build artifact
+      if: github.event == 'push'
+      uses: actions/upload-artifact@v2
+      with:
+        name: frontend
+        path: frontend/build
+
+  deploy:
+    if: github.event == 'push'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: frontend
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -114,3 +114,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Snowback build directory
+build/


### PR DESCRIPTION
This PR adds a GitHub Action to automatically build and deploy the frontend to GitHub Pages when updates occur. Unfortunately, I haven't been able to test this due to the way Actions work, but I think this will start working as expected as soon as this is merged. I also changed the .gitignore so that the frontend build folder won't get pushed into the repo if it exists.