### PR TITLE
Fix quiz by ID endpoint

### DIFF
--- a/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
+++ b/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 import java.util.Optional;
+import java.lang.ResponseEntity;
 
 @RequestMapping("api/quiz")
 @RestController

--- a/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
+++ b/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
@@ -3,14 +3,13 @@ package me.quizzl.backend.controllers;
 
 import me.quizzl.backend.models.Quiz;
 import me.quizzl.backend.services.QuizService;
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.Optional;
-import java.lang.ResponseEntity;
 
 @RequestMapping("api/quiz")
 @RestController

--- a/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
+++ b/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
@@ -31,4 +31,13 @@ public class QuizController {
     public List<Quiz> getQuizzes(){
         return quizService.getQuizzes();
     }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Quiz> getQuiz(@PathVariable String id){
+        var quiz = quizService.getQuizByID(UUID.fromString(id));
+        if (quiz.isPresent()) {
+            return new ResponseEntity<Quiz>(quiz.get(), HttpStatus.OK);
+        }
+        return new ResponseEntity<Quiz>(HttpStatus.NOT_FOUND);
+    }
 }

--- a/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
+++ b/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.Optional
+import java.util.Optional;
 
 @RequestMapping("api/quiz")
 @RestController

--- a/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
+++ b/backend/src/main/java/me/quizzl/backend/controllers/QuizController.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
+import java.util.Optional
 
 @RequestMapping("api/quiz")
 @RestController


### PR DESCRIPTION
There was a regression in a commit made in #14 resulting in the accidental removal in the `/api/quiz/{id}` endpoint added in #12. This PR reapplies the commits necessary to fix this.